### PR TITLE
Make do_stats.py more manageable

### DIFF
--- a/andy_adapter.py
+++ b/andy_adapter.py
@@ -4,6 +4,7 @@ import numpy as np
 
 
 class Andy2048(Base2048):
+    info = "Andy's implementation of 2048"
     UP = BoardEnv.UP
     RIGHT = BoardEnv.RIGHT
     DOWN = BoardEnv.DOWN

--- a/do_stats.py
+++ b/do_stats.py
@@ -1,278 +1,19 @@
 import sys
-import time
 import random
-from collections import defaultdict
-import numpy as np
-import statistics
+
+from strategies.random import try_random
+from strategies.only_go_right import try_only_go_right
+from strategies.down_left import try_down_left
+from strategies.fixed_action_order import try_fixed_action_order
+from strategies.greedy import try_greedy
+from strategies.greedy_fixed_order import try_greedy_fixed_order
+from strategies.down_left_greedy import try_down_left_greedy
+from strategies.max_space_then_greedy import try_max_space_then_greedy
+from strategies.lookahead import try_lookahead
+from strategies.mcts import try_mcts
+
 from nick_2048 import Nick2048
 from andy_adapter import Andy2048
-
-
-def do_trials(cls, trial_count, strategy, check_done_fn=None):
-    start_time = time.time()
-    scores = []
-    max_tiles = []
-    for i in range(trial_count):
-        game = cls()
-        curr_board, score, done = game.get_state()
-        while not done:
-            assert curr_board == game.board
-            move = strategy(curr_board)
-            prev_board = curr_board[:]
-            curr_board, reward, done = game.step(move)
-            if check_done_fn is not None:
-                done = check_done_fn(prev_board, curr_board, reward, done)
-        _, score, _ = game.get_state()
-        scores.append(score)
-        max_tiles.append(max(game.board))
-    elapsed = time.time() - start_time
-    elapsed_per_trial = elapsed / trial_count
-    elapsed = round(elapsed, 2)
-    elapsed_per_trial = round(elapsed_per_trial, 5)
-    print(
-        f"{strategy.info} "
-        f"({elapsed} sec total, {elapsed_per_trial} sec per trial):\n"
-        f"\tMax Tile: {max(max_tiles)}\n"
-        f"\tMax Score: {max(scores)}\n"
-        f"\tMean Score: {statistics.mean(scores)}\n"
-        f"\tMedian Score: {statistics.median(scores)}\n"
-        f"\tStandard Dev: {statistics.stdev(scores)}\n"
-        f"\tMin Score: {min(scores)}\n"
-    )
-
-
-def try_only_go_right(cls, trial_count):
-    def right_fn(board):
-        return cls.RIGHT
-
-    def right_done(prev, curr, reward, done):
-        return done or prev == curr
-
-    right_fn.info = "Strategy only moves right"
-    do_trials(cls, trial_count, right_fn, right_done)
-
-
-def try_random(cls, trial_count):
-    def random_fn(board):
-        choices = [cls.UP, cls.RIGHT, cls.DOWN, cls.LEFT]
-        return random.choice(choices)
-
-    random_fn.info = "Random strategy"
-    do_trials(cls, trial_count, random_fn)
-
-
-def try_down_left(cls, trial_count):
-    def down_left_fn(board):
-        action_rewards = Nick2048.get_valid_actions_from_board(board)
-        valid_actions = [a for (a, r, b) in action_rewards]
-        down_left = [cls.DOWN, cls.LEFT]
-        up_right = [cls.UP, cls.RIGHT]
-        random.shuffle(down_left)
-        random.shuffle(up_right)
-        for action in down_left + up_right:
-            if action in valid_actions:
-                return action
-        assert False, "should be able to do something"
-
-    down_left_fn.info = "Down Left strategy"
-    do_trials(cls, trial_count, down_left_fn)
-
-
-def try_fixed_action_order(cls, trial_count):
-    # Always choose actions in a particular order if they are valid
-    def fixed_fn(board):
-        ACTION_ORDER = [cls.DOWN, cls.LEFT, cls.UP, cls.RIGHT]
-        actions = Nick2048.get_valid_actions_from_board(board)
-        actions = [a for (a, r, b) in actions]
-        assert len(actions) > 0, "No actions available"
-        for action in ACTION_ORDER:
-            if action in actions:
-                return action
-        assert False, "Could not find action"
-
-    fixed_fn.info = "Fixed order strategy"
-    do_trials(cls, trial_count, fixed_fn)
-
-
-def try_greedy(cls, trial_count):
-    # Greedy, break ties randomly
-    def greedy_fn(board):
-        actions = Nick2048.get_valid_actions_by_reward_from_board(board)
-        assert len(actions) > 0, "No actions available"
-        return actions[0][0]
-
-    greedy_fn.info = "Greedy strategy"
-    do_trials(cls, trial_count, greedy_fn)
-
-
-def try_greedy_fixed_order(cls, trial_count):
-    ORDER = [cls.UP, cls.DOWN, cls.LEFT, cls.RIGHT]
-    random.shuffle(ORDER)
-
-    # Greedy, break ties in a fixed order
-    def greedy_fixed_order_fn(board):
-        actions = Nick2048.get_valid_actions_by_reward_from_board(board)
-        top_reward = actions[0][1]
-        equiv_rewards = [a for (a, r, b) in actions if r >= top_reward]
-        assert len(equiv_rewards) > 0, "No actions available"
-        for action in ORDER:
-            if action in equiv_rewards:
-                return action
-        assert False
-
-    greedy_fixed_order_fn.info = "Greedy strategy with fixed preference"
-    do_trials(cls, trial_count, greedy_fixed_order_fn)
-
-
-def try_down_left_greedy(cls, trial_count):
-    # pick best of {down, left} if available, otherwise best of {up, right}
-    def down_left_greedy_fn(board):
-        actions = Nick2048.get_valid_actions_by_reward_from_board(board)
-        assert len(actions) > 0, "No actions available"
-        for action, reward, board in actions:
-            if action in [cls.DOWN, cls.LEFT]:
-                return action
-        return actions[0][0]
-
-    down_left_greedy_fn.info = "Down left greedy strategy"
-    do_trials(cls, trial_count, down_left_greedy_fn)
-
-
-def try_max_space_then_greedy(cls, trial_count):
-    def max_space_then_greedy_fn(board):
-        actions = Nick2048.get_valid_actions_from_board(board)
-        assert len(actions) > 0, "No actions available"
-
-        def key_fn(el):
-            return (-1 * el[2].count(0), -1 * el[1])
-
-        sorted_actions = sorted(actions, key=key_fn)
-        top_action, top_reward, top_board = sorted_actions[0]
-        top_action_zeros = top_board.count(0)
-        for (a, r, b) in sorted_actions:
-            assert b.count(0) <= top_action_zeros
-        equiv_actions = [
-            a
-            for (a, r, b) in sorted_actions
-            if b.count(0) >= top_action_zeros and r >= top_reward
-        ]
-        ORDER = [cls.UP, cls.DOWN, cls.LEFT, cls.RIGHT]
-        for action in ORDER:
-            if action in equiv_actions:
-                return action
-        assert False
-
-    max_space_then_greedy_fn.info = "Max space then greedy"
-    do_trials(cls, trial_count, max_space_then_greedy_fn)
-
-
-def _get_lookahead_seqs(cls, action_space, lookahead_count):
-    lookahead_seqs = [(cls.UP,), (cls.DOWN,), (cls.LEFT,), (cls.RIGHT,)]
-    for i in range(lookahead_count - 1):
-        new_lookahead_seqs = []
-        for seq in lookahead_seqs:
-            for action in action_space:
-                new_lookahead_seqs.append((seq) + (action,))
-        lookahead_seqs = new_lookahead_seqs
-    return lookahead_seqs
-
-
-def get_lookahead_fn(cls, lookahead_count):
-    """Returns a function that takes a board and returns a suggested action."""
-    action_space = [cls.UP, cls.DOWN, cls.LEFT, cls.RIGHT]
-    lookahead_seqs = _get_lookahead_seqs(cls, action_space, lookahead_count)
-
-    # try each lookahead sequence, return the max action
-    def lookahead_fn(board):
-        action_rewards = cls.get_valid_actions_from_board(board)
-        valid_actions = [a for (a, r, b) in action_rewards]
-        test_board = cls()
-        max_score = 0
-        max_actions = set()
-        for sequence in lookahead_seqs:
-            if sequence[0] not in valid_actions:
-                continue
-            test_board.score = 0
-            test_board.set_board(board)
-            for action in sequence:
-                test_board.step(action)
-            if test_board.score > max_score:
-                max_actions = set([sequence[0]])
-                max_score = test_board.score
-            if test_board.score == max_score:
-                max_actions.add(sequence[0])
-        for action in action_space:
-            if action in max_actions:
-                return action
-        assert False
-
-    return lookahead_fn
-
-
-def try_lookahead(cls, trial_count, lookahead_count):
-    lookahead_fn = get_lookahead_fn(cls, lookahead_count)
-    lookahead_fn.info = f"Lookahead {lookahead_count} strategy"
-    do_trials(cls, trial_count, lookahead_fn)
-
-
-# globals so that we'll keep value function state across training rollouts
-n = defaultdict(int)  # tuple(board), action -> count of visits
-sum_ret = defaultdict(int)  # tuple(board), action -> expected return val
-
-
-def train_mcts(cls, next_action, num_rollouts=100000):
-    epsilon = 0.1
-    discount_rate = 0.95
-    print("training MCTS value function")
-    for rollout_num in range(num_rollouts):
-        if rollout_num % 2000 == 0:
-            print("training rollout num %s" % rollout_num)
-        game = cls()
-        curr_board, score, done = game.get_state()
-        states, actions, rewards = [], [], []
-        while not done:
-            assert curr_board == game.board
-            if random.random() < epsilon:
-                action = cls.random_direction()
-            else:
-                action = next_action(curr_board)
-            states.append(curr_board)
-            curr_board, reward, done = game.step(action)
-            actions.append(action)
-            rewards.append(reward)
-
-        # calculate returns (i.e., discounted future rewards) using bellman backups for the rollout just completed
-        returns = [0] * len(rewards)
-        returns[-1] = rewards[-1]
-        for i in range(len(rewards) - 2, -1, -1):
-            n[(tuple(states[i]), actions[i])] += 1
-            sum_ret[(tuple(states[i]), actions[i])] += (
-                rewards[i] + discount_rate * returns[i + 1]
-            )
-
-
-def try_mcts(cls, trial_count):
-    action_space = cls().action_space
-
-    def q(s, a):
-        if n[(tuple(s), a)]:
-            return sum_ret[(tuple(s), a)] / n[(tuple(s), a)]
-        else:
-            return 0
-
-    def next_action(s):
-        # return np.argmax([q(s, a) for a in action_space])
-        # break ties with random coin flip.
-        action_values = np.array([q(s, a) for a in action_space])
-        return np.random.choice(np.flatnonzero(action_values == action_values.max()))
-
-    def mcts_fn(board):
-        return next_action(board)
-
-    mcts_fn.info = "MCTS strategy"
-    for _ in range(10):
-        train_mcts(cls, next_action, 10000)
-        do_trials(cls, trial_count, mcts_fn)
 
 
 def print_usage(impls, strats):
@@ -288,65 +29,69 @@ def print_usage(impls, strats):
     print()
 
     print(f"[implementation] is one of:")
-    for key, (cls, desc) in impls.items():
-        print(f"\t{key} - {desc}")
+    for key, val in impls.items():
+        try:
+            print(f"\t{key} - {val.info}")
+        except AttributeError:
+            print(f"\t{key} - no description")
     print()
 
     print(f"[strategy] is one of:")
-    for key, (cls, desc) in strats.items():
-        print(f"\t{key} - {desc}")
+    for key, val in strats.items():
+        try:
+            print(f"\t{key} - {val.info}")
+        except AttributeError:
+            print(f"\t{key} - no description")
     print()
 
 
 if __name__ == "__main__":
     impls = {
-        "nick": (Nick2048, "Nick's implemenation of 2048"),
-        "andy": (Andy2048, "Andy's implementation of 2048"),
+        "nick": Nick2048,
+        "andy": Andy2048,
     }
-    lookahead_str = "A Monte Carlo tree search variant with depth limited to {}."
+    lookahead_str = "Monte Carlo tree search variant with depth limited to {}."
+
+    def try_lookahead_1(impl, trials):
+        try_lookahead(impl, trials, 1)
+
+    try_lookahead_1.info = lookahead_str.format(1)
+
+    def try_lookahead_2(impl, trials):
+        try_lookahead(impl, trials, 2)
+
+    try_lookahead_2.info = lookahead_str.format(2)
+
+    def try_lookahead_3(impl, trials):
+        try_lookahead(impl, trials, 3)
+
+    try_lookahead_3.info = lookahead_str.format(3)
+
+    def try_lookahead_4(impl, trials):
+        try_lookahead(impl, trials, 4)
+
+    try_lookahead_4.info = lookahead_str.format(4)
+
+    def try_lookahead_5(impl, trials):
+        try_lookahead(impl, trials, 5)
+
+    try_lookahead_5.info = lookahead_str.format(5)
+
     strats = {
-        "only_go_right": (
-            try_only_go_right,
-            "Only go right, " "end when board stops changing",
-        ),
-        "random": (try_random, "Try random moves until game over"),
-        "down_left": (
-            try_down_left,
-            "Only go down or left "
-            "until you get stuck, then randomly go up or right once",
-        ),
-        "fixed_action_order": (
-            try_fixed_action_order,
-            "Always choose actions in a fixed order if they are valid "
-            "(Down > Left > Up > Right)",
-        ),
-        "greedy": (
-            try_greedy,
-            "Choose action that results in best score, tiebreak randomly",
-        ),
-        "greedy_fixed_order": (
-            try_greedy_fixed_order,
-            "Choose action that results in best score, fixed order tiebreak "
-            "(Up > Down > Left > Right)",
-        ),
-        "down_left_greedy": (
-            try_down_left_greedy,
-            "Pick best of {down, left} if allowed, else best of {up, right}",
-        ),
-        "max_space_then_greedy": (
-            try_max_space_then_greedy,
-            "Pick moves greedily with respect to free space on board, "
-            "tiebreak by being greedy w.r.t. score",
-        ),
-        "lookahead_1": (
-            lambda i, t: try_lookahead(i, t, 1),
-            "Should be equivalent to greedy; picks move with best score",
-        ),
-        "lookahead_2": (lambda i, t: try_lookahead(i, t, 2), lookahead_str.format(2)),
-        "lookahead_3": (lambda i, t: try_lookahead(i, t, 3), lookahead_str.format(3)),
-        "lookahead_4": (lambda i, t: try_lookahead(i, t, 4), lookahead_str.format(4)),
-        "lookahead_5": (lambda i, t: try_lookahead(i, t, 5), lookahead_str.format(5)),
-        "mcts": (try_mcts, "Classic Monte Carlo tree search algorithm"),
+        "only_go_right": try_only_go_right,
+        "random": try_random,
+        "down_left": try_down_left,
+        "fixed_action_order": try_fixed_action_order,
+        "greedy": try_greedy,
+        "greedy_fixed_order": try_greedy_fixed_order,
+        "down_left_greedy": try_down_left_greedy,
+        "max_space_then_greedy": try_max_space_then_greedy,
+        "lookahead_1": try_lookahead_1,
+        "lookahead_2": try_lookahead_2,
+        "lookahead_3": try_lookahead_3,
+        "lookahead_4": try_lookahead_4,
+        "lookahead_5": try_lookahead_5,
+        "mcts": try_mcts,
     }
 
     if len(sys.argv) != 4:
@@ -362,9 +107,10 @@ if __name__ == "__main__":
         sys.exit(0)
 
     print(
-        f"\nRunning {trial_count} trials with {impl_name}'s impl to test {strat_name}\n"
+        f"\nRunning {trial_count} trials with "
+        f"{impl_name}'s impl to test {strat_name}\n"
     )
 
-    implementation = impls[impl_name][0]
-    strategy = strats[strat_name][0]
+    implementation = impls[impl_name]
+    strategy = strats[strat_name]
     strategy(implementation, trial_count)

--- a/do_stats.py
+++ b/do_stats.py
@@ -15,21 +15,81 @@ from strategies.mcts import try_mcts
 from nick_2048 import Nick2048
 from andy_adapter import Andy2048
 
+IMPLEMENTATIONS = {
+    "nick": Nick2048,
+    "andy": Andy2048,
+}
 
-def print_usage(impls, strats):
+lookahead_str = "Monte Carlo tree search variant with depth limited to {}."
+
+
+def try_lookahead_1(impl, trials):
+    try_lookahead(impl, trials, 1)
+
+
+try_lookahead_1.info = lookahead_str.format(1)
+
+
+def try_lookahead_2(impl, trials):
+    try_lookahead(impl, trials, 2)
+
+
+try_lookahead_2.info = lookahead_str.format(2)
+
+
+def try_lookahead_3(impl, trials):
+    try_lookahead(impl, trials, 3)
+
+
+try_lookahead_3.info = lookahead_str.format(3)
+
+
+def try_lookahead_4(impl, trials):
+    try_lookahead(impl, trials, 4)
+
+
+try_lookahead_4.info = lookahead_str.format(4)
+
+
+def try_lookahead_5(impl, trials):
+    try_lookahead(impl, trials, 5)
+
+
+try_lookahead_5.info = lookahead_str.format(5)
+
+
+STRATEGIES = {
+    "only_go_right": try_only_go_right,
+    "random": try_random,
+    "down_left": try_down_left,
+    "fixed_action_order": try_fixed_action_order,
+    "greedy": try_greedy,
+    "greedy_fixed_order": try_greedy_fixed_order,
+    "down_left_greedy": try_down_left_greedy,
+    "max_space_then_greedy": try_max_space_then_greedy,
+    "lookahead_1": try_lookahead_1,
+    "lookahead_2": try_lookahead_2,
+    "lookahead_3": try_lookahead_3,
+    "lookahead_4": try_lookahead_4,
+    "lookahead_5": try_lookahead_5,
+    "mcts": try_mcts,
+}
+
+
+def print_usage():
     print()
     print("Usage:")
     print(f"\tpython {sys.argv[0]} [implementation] [trial_count] [strategy]")
     print()
     print("Example:")
-    impl = random.choice(list(impls.keys()))
-    strat = random.choice(list(strats.keys()))
+    impl = random.choice(list(IMPLEMENTATIONS.keys()))
+    strat = random.choice(list(STRATEGIES.keys()))
     print(f"\tpython {sys.argv[0]} {impl} 100 {strat}")
     print()
     print()
 
     print(f"[implementation] is one of:")
-    for key, val in impls.items():
+    for key, val in IMPLEMENTATIONS.items():
         try:
             print(f"\t{key} - {val.info}")
         except AttributeError:
@@ -37,7 +97,7 @@ def print_usage(impls, strats):
     print()
 
     print(f"[strategy] is one of:")
-    for key, val in strats.items():
+    for key, val in STRATEGIES.items():
         try:
             print(f"\t{key} - {val.info}")
         except AttributeError:
@@ -46,64 +106,17 @@ def print_usage(impls, strats):
 
 
 if __name__ == "__main__":
-    impls = {
-        "nick": Nick2048,
-        "andy": Andy2048,
-    }
-    lookahead_str = "Monte Carlo tree search variant with depth limited to {}."
-
-    def try_lookahead_1(impl, trials):
-        try_lookahead(impl, trials, 1)
-
-    try_lookahead_1.info = lookahead_str.format(1)
-
-    def try_lookahead_2(impl, trials):
-        try_lookahead(impl, trials, 2)
-
-    try_lookahead_2.info = lookahead_str.format(2)
-
-    def try_lookahead_3(impl, trials):
-        try_lookahead(impl, trials, 3)
-
-    try_lookahead_3.info = lookahead_str.format(3)
-
-    def try_lookahead_4(impl, trials):
-        try_lookahead(impl, trials, 4)
-
-    try_lookahead_4.info = lookahead_str.format(4)
-
-    def try_lookahead_5(impl, trials):
-        try_lookahead(impl, trials, 5)
-
-    try_lookahead_5.info = lookahead_str.format(5)
-
-    strats = {
-        "only_go_right": try_only_go_right,
-        "random": try_random,
-        "down_left": try_down_left,
-        "fixed_action_order": try_fixed_action_order,
-        "greedy": try_greedy,
-        "greedy_fixed_order": try_greedy_fixed_order,
-        "down_left_greedy": try_down_left_greedy,
-        "max_space_then_greedy": try_max_space_then_greedy,
-        "lookahead_1": try_lookahead_1,
-        "lookahead_2": try_lookahead_2,
-        "lookahead_3": try_lookahead_3,
-        "lookahead_4": try_lookahead_4,
-        "lookahead_5": try_lookahead_5,
-        "mcts": try_mcts,
-    }
 
     if len(sys.argv) != 4:
-        print_usage(impls, strats)
+        print_usage()
         sys.exit(0)
 
     impl_name = sys.argv[1]
     trial_count = int(sys.argv[2])
     strat_name = sys.argv[3]
 
-    if impl_name not in impls or strat_name not in strats:
-        print_usage(impls, strats)
+    if impl_name not in IMPLEMENTATIONS or strat_name not in STRATEGIES:
+        print_usage()
         sys.exit(0)
 
     print(
@@ -111,6 +124,6 @@ if __name__ == "__main__":
         f"{impl_name}'s impl to test {strat_name}\n"
     )
 
-    implementation = impls[impl_name]
-    strategy = strats[strat_name]
+    implementation = IMPLEMENTATIONS[impl_name]
+    strategy = STRATEGIES[strat_name]
     strategy(implementation, trial_count)

--- a/nick_2048.py
+++ b/nick_2048.py
@@ -13,6 +13,7 @@ from base_2048 import Base2048
 
 
 class Nick2048(Base2048):
+    info = "Nick's implementation of 2048"
     RIGHT = 0
     DOWN = 1
     LEFT = 2

--- a/strategies/down_left.py
+++ b/strategies/down_left.py
@@ -1,0 +1,24 @@
+import random
+from strategies.utility import do_trials
+
+
+def try_down_left(cls, trial_count):
+    def down_left_fn(board):
+        action_rewards = cls.get_valid_actions_from_board(board)
+        valid_actions = [a for (a, r, b) in action_rewards]
+        down_left = [cls.DOWN, cls.LEFT]
+        up_right = [cls.UP, cls.RIGHT]
+        random.shuffle(down_left)
+        random.shuffle(up_right)
+        for action in down_left + up_right:
+            if action in valid_actions:
+                return action
+        assert False, "should be able to do something"
+
+    down_left_fn.info = "Down Left strategy"
+    do_trials(cls, trial_count, down_left_fn)
+
+
+try_down_left.info = (
+    "Only go down or left " "until you get stuck, then randomly go up or right once"
+)

--- a/strategies/down_left_greedy.py
+++ b/strategies/down_left_greedy.py
@@ -1,0 +1,20 @@
+from strategies.utility import do_trials
+
+
+def try_down_left_greedy(cls, trial_count):
+    # pick best of {down, left} if available, otherwise best of {up, right}
+    def down_left_greedy_fn(board):
+        actions = cls.get_valid_actions_by_reward_from_board(board)
+        assert len(actions) > 0, "No actions available"
+        for action, reward, board in actions:
+            if action in [cls.DOWN, cls.LEFT]:
+                return action
+        return actions[0][0]
+
+    down_left_greedy_fn.info = "Down left greedy strategy"
+    do_trials(cls, trial_count, down_left_greedy_fn)
+
+
+try_down_left_greedy.info = (
+    "Pick best of {down, left} if allowed, else best of {up, right}"
+)

--- a/strategies/fixed_action_order.py
+++ b/strategies/fixed_action_order.py
@@ -1,0 +1,23 @@
+from strategies.utility import do_trials
+
+
+def try_fixed_action_order(cls, trial_count):
+    # Always choose actions in a particular order if they are valid
+    def fixed_fn(board):
+        ACTION_ORDER = [cls.DOWN, cls.LEFT, cls.UP, cls.RIGHT]
+        actions = cls.get_valid_actions_from_board(board)
+        actions = [a for (a, r, b) in actions]
+        assert len(actions) > 0, "No actions available"
+        for action in ACTION_ORDER:
+            if action in actions:
+                return action
+        assert False, "Could not find action"
+
+    fixed_fn.info = "Fixed order strategy"
+    do_trials(cls, trial_count, fixed_fn)
+
+
+try_fixed_action_order.info = (
+    "Always choose actions in a fixed order if they are valid "
+    "(Down > Left > Up > Right)"
+)

--- a/strategies/greedy.py
+++ b/strategies/greedy.py
@@ -1,0 +1,15 @@
+from strategies.utility import do_trials
+
+
+def try_greedy(cls, trial_count):
+    # Greedy, break ties randomly
+    def greedy_fn(board):
+        actions = cls.get_valid_actions_by_reward_from_board(board)
+        assert len(actions) > 0, "No actions available"
+        return actions[0][0]
+
+    greedy_fn.info = "Greedy strategy"
+    do_trials(cls, trial_count, greedy_fn)
+
+
+try_greedy.info = "Choose action that results in best score, tiebreak randomly"

--- a/strategies/greedy_fixed_order.py
+++ b/strategies/greedy_fixed_order.py
@@ -1,0 +1,27 @@
+import random
+from strategies.utility import do_trials
+
+
+def try_greedy_fixed_order(cls, trial_count):
+    ORDER = [cls.UP, cls.DOWN, cls.LEFT, cls.RIGHT]
+    random.shuffle(ORDER)
+
+    # Greedy, break ties in a fixed order
+    def greedy_fixed_order_fn(board):
+        actions = cls.get_valid_actions_by_reward_from_board(board)
+        top_reward = actions[0][1]
+        equiv_rewards = [a for (a, r, b) in actions if r >= top_reward]
+        assert len(equiv_rewards) > 0, "No actions available"
+        for action in ORDER:
+            if action in equiv_rewards:
+                return action
+        assert False
+
+    greedy_fixed_order_fn.info = "Greedy strategy with fixed preference"
+    do_trials(cls, trial_count, greedy_fixed_order_fn)
+
+
+try_greedy_fixed_order.info = (
+    "Choose action that results in best score, fixed order tiebreak "
+    "(e.g. Up > Down > Left > Right)"
+)

--- a/strategies/lookahead.py
+++ b/strategies/lookahead.py
@@ -1,0 +1,50 @@
+from strategies.utility import do_trials
+
+
+def _get_lookahead_seqs(cls, action_space, lookahead_count):
+    lookahead_seqs = [(cls.UP,), (cls.DOWN,), (cls.LEFT,), (cls.RIGHT,)]
+    for i in range(lookahead_count - 1):
+        new_lookahead_seqs = []
+        for seq in lookahead_seqs:
+            for action in action_space:
+                new_lookahead_seqs.append((seq) + (action,))
+        lookahead_seqs = new_lookahead_seqs
+    return lookahead_seqs
+
+
+def get_lookahead_fn(cls, lookahead_count):
+    """Returns a function that takes a board and returns a suggested action."""
+    action_space = [cls.UP, cls.DOWN, cls.LEFT, cls.RIGHT]
+    lookahead_seqs = _get_lookahead_seqs(cls, action_space, lookahead_count)
+
+    # try each lookahead sequence, return the max action
+    def lookahead_fn(board):
+        action_rewards = cls.get_valid_actions_from_board(board)
+        valid_actions = [a for (a, r, b) in action_rewards]
+        test_board = cls()
+        max_score = 0
+        max_actions = set()
+        for sequence in lookahead_seqs:
+            if sequence[0] not in valid_actions:
+                continue
+            test_board.score = 0
+            test_board.set_board(board)
+            for action in sequence:
+                test_board.step(action)
+            if test_board.score > max_score:
+                max_actions = set([sequence[0]])
+                max_score = test_board.score
+            if test_board.score == max_score:
+                max_actions.add(sequence[0])
+        for action in action_space:
+            if action in max_actions:
+                return action
+        assert False
+
+    return lookahead_fn
+
+
+def try_lookahead(cls, trial_count, lookahead_count):
+    lookahead_fn = get_lookahead_fn(cls, lookahead_count)
+    lookahead_fn.info = f"Lookahead {lookahead_count} strategy"
+    do_trials(cls, trial_count, lookahead_fn)

--- a/strategies/max_space_then_greedy.py
+++ b/strategies/max_space_then_greedy.py
@@ -1,0 +1,35 @@
+from strategies.utility import do_trials
+
+
+def try_max_space_then_greedy(cls, trial_count):
+    def max_space_then_greedy_fn(board):
+        actions = cls.get_valid_actions_from_board(board)
+        assert len(actions) > 0, "No actions available"
+
+        def key_fn(el):
+            return (-1 * el[2].count(0), -1 * el[1])
+
+        sorted_actions = sorted(actions, key=key_fn)
+        top_action, top_reward, top_board = sorted_actions[0]
+        top_action_zeros = top_board.count(0)
+        for (a, r, b) in sorted_actions:
+            assert b.count(0) <= top_action_zeros
+        equiv_actions = [
+            a
+            for (a, r, b) in sorted_actions
+            if b.count(0) >= top_action_zeros and r >= top_reward
+        ]
+        ORDER = [cls.UP, cls.DOWN, cls.LEFT, cls.RIGHT]
+        for action in ORDER:
+            if action in equiv_actions:
+                return action
+        assert False
+
+    max_space_then_greedy_fn.info = "Max space then greedy"
+    do_trials(cls, trial_count, max_space_then_greedy_fn)
+
+
+try_max_space_then_greedy.info = (
+    "Pick moves greedily with respect to free space on board, "
+    "tiebreak by being greedy w.r.t. score"
+)

--- a/strategies/mcts.py
+++ b/strategies/mcts.py
@@ -1,0 +1,66 @@
+import random
+from collections import defaultdict
+import numpy as np
+from strategies.utility import do_trials
+
+# globals so that we'll keep value function state across training rollouts
+n = defaultdict(int)  # tuple(board), action -> count of visits
+sum_ret = defaultdict(int)  # tuple(board), action -> expected return val
+
+
+def train_mcts(cls, next_action, num_rollouts=100000):
+    epsilon = 0.1
+    discount_rate = 0.95
+    print("training MCTS value function")
+    for rollout_num in range(num_rollouts):
+        if rollout_num % 2000 == 0:
+            print("training rollout num %s" % rollout_num)
+        game = cls()
+        curr_board, score, done = game.get_state()
+        states, actions, rewards = [], [], []
+        while not done:
+            assert curr_board == game.board
+            if random.random() < epsilon:
+                action = cls.random_direction()
+            else:
+                action = next_action(curr_board)
+            states.append(curr_board)
+            curr_board, reward, done = game.step(action)
+            actions.append(action)
+            rewards.append(reward)
+
+        # calculate returns (i.e., discounted future rewards) using bellman backups for the rollout just completed
+        returns = [0] * len(rewards)
+        returns[-1] = rewards[-1]
+        for i in range(len(rewards) - 2, -1, -1):
+            n[(tuple(states[i]), actions[i])] += 1
+            sum_ret[(tuple(states[i]), actions[i])] += (
+                rewards[i] + discount_rate * returns[i + 1]
+            )
+
+
+def try_mcts(cls, trial_count):
+    action_space = cls().action_space
+
+    def q(s, a):
+        if n[(tuple(s), a)]:
+            return sum_ret[(tuple(s), a)] / n[(tuple(s), a)]
+        else:
+            return 0
+
+    def next_action(s):
+        # return np.argmax([q(s, a) for a in action_space])
+        # break ties with random coin flip.
+        action_values = np.array([q(s, a) for a in action_space])
+        return np.random.choice(np.flatnonzero(action_values == action_values.max()))
+
+    def mcts_fn(board):
+        return next_action(board)
+
+    mcts_fn.info = "MCTS strategy"
+    for _ in range(10):
+        train_mcts(cls, next_action, 10000)
+        do_trials(cls, trial_count, mcts_fn)
+
+
+try_mcts.info = "Classic Monte Carlo tree search algorithm"

--- a/strategies/only_go_right.py
+++ b/strategies/only_go_right.py
@@ -1,0 +1,15 @@
+from strategies.utility import do_trials
+
+
+def try_only_go_right(cls, trial_count):
+    def right_fn(board):
+        return cls.RIGHT
+
+    def right_done(prev, curr, reward, done):
+        return done or prev == curr
+
+    right_fn.info = "Strategy only moves right"
+    do_trials(cls, trial_count, right_fn, right_done)
+
+
+try_only_go_right.info = "Only go right, and end when board stops changing"

--- a/strategies/random.py
+++ b/strategies/random.py
@@ -1,0 +1,14 @@
+import random
+from strategies.utility import do_trials
+
+
+def try_random(cls, trial_count):
+    def random_fn(board):
+        choices = [cls.UP, cls.RIGHT, cls.DOWN, cls.LEFT]
+        return random.choice(choices)
+
+    random_fn.info = "Random strategy"
+    do_trials(cls, trial_count, random_fn)
+
+
+try_random.info = "Try random moves until game over"

--- a/strategies/utility.py
+++ b/strategies/utility.py
@@ -1,0 +1,35 @@
+import time
+import statistics
+
+
+def do_trials(cls, trial_count, strategy, check_done_fn=None):
+    start_time = time.time()
+    scores = []
+    max_tiles = []
+    for i in range(trial_count):
+        game = cls()
+        curr_board, score, done = game.get_state()
+        while not done:
+            assert curr_board == game.board
+            move = strategy(curr_board)
+            prev_board = curr_board[:]
+            curr_board, reward, done = game.step(move)
+            if check_done_fn is not None:
+                done = check_done_fn(prev_board, curr_board, reward, done)
+        _, score, _ = game.get_state()
+        scores.append(score)
+        max_tiles.append(max(game.board))
+    elapsed = time.time() - start_time
+    elapsed_per_trial = elapsed / trial_count
+    elapsed = round(elapsed, 2)
+    elapsed_per_trial = round(elapsed_per_trial, 5)
+    print(
+        f"{strategy.info} "
+        f"({elapsed} sec total, {elapsed_per_trial} sec per trial):\n"
+        f"\tMax Tile: {max(max_tiles)}\n"
+        f"\tMax Score: {max(scores)}\n"
+        f"\tMean Score: {statistics.mean(scores)}\n"
+        f"\tMedian Score: {statistics.median(scores)}\n"
+        f"\tStandard Dev: {statistics.stdev(scores)}\n"
+        f"\tMin Score: {min(scores)}\n"
+    )

--- a/test_do_stats.py
+++ b/test_do_stats.py
@@ -1,0 +1,16 @@
+from nick_2048 import Nick2048
+from do_stats import STRATEGIES, IMPLEMENTATIONS
+from strategies.random import try_random
+
+
+def test_strategies():
+    SKIP = ["lookahead_3", "lookahead_4", "lookahead_5", "mcts"]
+    for strat_name, strategy in STRATEGIES.items():
+        if strat_name in SKIP:
+            continue
+        strategy(Nick2048, 2)
+
+
+def test_implementations():
+    for impl_name, implementation in IMPLEMENTATIONS.items():
+        try_random(implementation, 2)


### PR DESCRIPTION
FYI @andyk 

Do some refactoring to `do_stats.py` to make things a bit more manageable.  Not sure I'm in love with the result, but let's give it a shot.  You can now run specific strategies from the commandline, for example:

```python do_stats.py nick 100 mcts```

runs 100 trials using `Nick2048` implementation with the `mcts` algo you programmed.

```python do_stats.py```

lists available strategies etc.