### PR TITLE
Add lookahead+rollout strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,23 @@ Here's how various 2048 strategies perform
 implementation with the named strategy,
 tested on a 2012 macbook air with 1.8GHz i5 and 4GB of 1600MHz DDR3 RAM):
 
-| Strategy           | Max observed tile | Mean Score    | Score Standard Dev | Mean steps per game | Mean sec per game  |
-| -----------------  | ----------------: | ------------: | -----------------: |-------------------: | -----------------: |
-| Only Go Right      | 16                | 13            | 18                 | 6                   |   .00005 sec        |
-| Random             | 256               | 1058          | 504                | 138                 |   .006 sec          |
-| Down Left          | 512               | 2332          | 1131               | 207                 |   .05 sec           |
-| Fixed order        | 512               | 2492          | 1345               | 221                 |   .05 sec           |
-| Greedy             | 512               | 2122          | 930                | 188                 |   .05 sec           |
-| Greedy Fixed Order | 512               | 3028          | 1580               | 256                 |   .06 sec           |
-| Down Left Greedy   | 512               | 2107          | 1076               | 192                 |   .05 sec           |
-| Max Space Greedy   | 512               | 3157          | 1477               | 266                 |   .06 sec           |
-| Lookahead 1        | 1024              | 3008          | 1864               | 252                 |   .1 sec            |
-| Lookahead 2        | 1024              | 7446          | 3157               | 491                 |   .7 sec            |
-| Lookahead 3        | 1024              | 11659         | 3958               | 710                 |  5.1 sec            |
-| Lookahead 4        | 2048              | 16757         | 7443               | 945                 | 33.1 sec            |
+| Strategy                 | Max tile | Max Score | Mean Score    | Score Standard Dev | Mean steps per game | Mean sec per game    | Git Hash   |
+| ------------------------ | -------: | --------: | ------------: | -----------------: |-------------------: | -------------------: | --------:  |
+| Only Go Right            | 16       |           | 13            | 18                 | 6                   |     .00005 sec       |            |
+| Random                   | 256      |           | 1058          | 504                | 138                 |     .006 sec         |            |
+| Down Left                | 512      |           | 2332          | 1131               | 207                 |     .05 sec          |            |
+| Fixed order              | 512      |           | 2492          | 1345               | 221                 |     .05 sec          |            |
+| Greedy                   | 512      |           | 2122          | 930                | 188                 |     .05 sec          |            |
+| Greedy Fixed Order       | 512      |           | 3028          | 1580               | 256                 |     .06 sec          |            |
+| Down Left Greedy         | 512      |           | 2107          | 1076               | 192                 |     .05 sec          |            |
+| Max Space Greedy         | 512      |           | 3157          | 1477               | 266                 |     .06 sec          |            |
+| Lookahead 1              | 1024     |           | 3008          | 1864               | 252                 |     .1 sec           |            |
+| Lookahead 2              | 1024     |           | 7446          | 3157               | 491                 |     .7 sec           |            |
+| Lookahead 3              | 1024     |           | 11659         | 3958               | 710                 |    5.1 sec           |            |
+| Lookahead 4              | 2048     |           | 16757         | 7443               | 945                 |   33.1 sec           |            |
+| Lookahead 3 + rollouts<sup>1</sup> | 4096 | 75832 | 36670       | 14124              | 1853                |  758 sec             | c3bb225    |
 
+1. Lookahead 3 that switches to 150 random rollouts per move when board has <= 7 empty spaces
 
 ## Setup
 

--- a/contrib/reinforce.py
+++ b/contrib/reinforce.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 
 params = {"board_width": 4,
           "num_iters": 2,
-          "num_episodes_per_iter":10,
+          "num_episodes_per_iter": 10,
           "max_steps_per_episode": 500,
           "discount_rate": 0.95,
           "epsilon_base": 0.2,

--- a/do_stats.py
+++ b/do_stats.py
@@ -12,6 +12,7 @@ from strategies.max_space_then_greedy import try_max_space_then_greedy
 from strategies.lookahead import try_lookahead
 from strategies.mcts import try_mcts
 from strategies.mcts_dynamic import try_mcts_dynamic
+from strategies.lookahead_with_rollout import try_lookahead_with_rollout
 
 from envs.nick_2048 import Nick2048
 from envs.nick_gym_adapter import Nick2048Gym
@@ -77,6 +78,7 @@ STRATEGIES = {
     "lookahead_5": try_lookahead_5,
     "mcts": try_mcts,
     "mcts_dynamic": try_mcts_dynamic,
+    "lookahead_with_rollout": try_lookahead_with_rollout,
 }
 
 

--- a/strategies/lookahead_with_rollout.py
+++ b/strategies/lookahead_with_rollout.py
@@ -1,0 +1,44 @@
+import statistics
+import random
+from strategies.utility import do_trials
+from strategies.lookahead import get_lookahead_fn
+
+LOOKAHEAD_COUNT = 3
+ROLLOUT_THRESHOLD = LOOKAHEAD_COUNT + 4
+ROLLOUTS_PER_MOVE = 150
+
+
+def best_next_move_from_random_rollouts(cls, board):
+    action_rewards = cls.get_valid_actions_from_board(board)
+    valid_actions = [a for (a, r, b) in action_rewards]
+    avg_steps = {}
+    test_game = cls()
+    for action in valid_actions:
+        scores = []
+        for i in range(ROLLOUTS_PER_MOVE):
+            test_game.score = 0
+            test_game.set_board(board)
+            test_game.step(action)
+            while not test_game.done:
+                test_game.step(random.choice(test_game.action_space))
+            scores.append(test_game.score)
+        avg_steps[action] = statistics.mean(scores)
+    action = max(avg_steps.items(), key=lambda x: x[1])[0]
+    return action
+
+
+def try_lookahead_with_rollout(cls, trial_count):
+    lookahead_fn = get_lookahead_fn(cls, LOOKAHEAD_COUNT)
+
+    def lookahead_with_rollout_fn(board):
+        if len([v for v in board if v == 0]) > ROLLOUT_THRESHOLD:
+            return lookahead_fn(board)
+        else:
+            return best_next_move_from_random_rollouts(cls, board)
+
+    lookahead_with_rollout_fn.info = f"Lookahead {LOOKAHEAD_COUNT} with "
+    lookahead_with_rollout_fn.info += f"{ROLLOUTS_PER_MOVE} "
+    lookahead_with_rollout_fn.info += f"random rollouts per move "
+    lookahead_with_rollout_fn.info += f"when board has <= {ROLLOUT_THRESHOLD} "
+    lookahead_with_rollout_fn.info += f"empty spaces"
+    do_trials(cls, trial_count, lookahead_with_rollout_fn, always_print=True)

--- a/strategies/random.py
+++ b/strategies/random.py
@@ -8,7 +8,7 @@ def try_random(cls, trial_count):
         return random.choice(choices)
 
     random_fn.info = "Random strategy"
-    do_trials(cls, trial_count, random_fn)
+    do_trials(cls, trial_count, random_fn, always_print=True)
 
 
 try_random.info = "Try random moves until game over"


### PR DESCRIPTION
Adds a lookahead strategy that switches over to random rollouts once the board gets constrained.  The best run over a trial of 100 just barely edged out Jakey's high score  (75832 vs 75192) 🤣.  Also, add some more info in the trials print out. 

```

Final Results
Lookahead 3 with 150 random rollouts per move when board has <= 7 empty spaces (100 trials, 75796.67 sec total, 757.96665 sec per trial):

	Mean steps per game: 1852.8
	Mean time per step: 0.40909

	Max Tiles:
		4096: 18 (18.0%)
		2048: 66 (66.0%)
		1024: 16 (16.0%)

	Max Score: 75832
	Mean Score: 36670.12
	Median Score: 36184.0
	Standard Dev: 14123.830017714492
	Min Score: 12172

```