### PR TITLE
Nj rotate and canonicalize

### DIFF
--- a/envs/nick_2048.py
+++ b/envs/nick_2048.py
@@ -250,7 +250,8 @@ class Nick2048(Base2048):
             idx = random.choice(self.empty_indexes)
         except IndexError:
             return -1
-        board = self.board[:idx] + (value,) + self.board[idx + 1:]
+        idx_plus_one = idx + 1
+        board = self.board[:idx] + (value,) + self.board[idx_plus_one:]
         self.set_board(board)
         return idx
 

--- a/envs/nick_2048.py
+++ b/envs/nick_2048.py
@@ -30,6 +30,35 @@ class Nick2048(Base2048):
         self.reset()
 
     @classmethod
+    def get_canonical_board(cls, board):
+        r0 = board
+        r90 = cls.rotate_board_right(board)
+        r180 = cls.rotate_board_right(r90)
+        r270 = cls.rotate_board_right(r180)
+        xr0 = cls.reflect_board_across_x(board)
+        xr90 = cls.rotate_board_right(xr0)
+        xr180 = cls.rotate_board_right(xr90)
+        xr270 = cls.rotate_board_right(xr180)
+        yr0 = cls.reflect_board_across_y(board)
+        yr90 = cls.rotate_board_right(yr0)
+        yr180 = cls.rotate_board_right(yr90)
+        yr270 = cls.rotate_board_right(yr180)
+        rotations_and_reflections = set(
+            [r0, r90, r180, r270, xr0, xr90, xr180, xr270, yr0, yr90, yr180, yr270]
+        )
+        # treat each board as a 16 digit number (where each digit is 0 to 2^17)
+        # return the board that corresponds to the largest digit.
+        for idx in range(16):
+            max_num = max(r[idx] for r in rotations_and_reflections)
+            rotations_and_reflections = set(
+                [r for r in rotations_and_reflections if r[idx] >= max_num]
+            )
+            if len(rotations_and_reflections) == 1:
+                break
+        assert len(rotations_and_reflections) == 1
+        return rotations_and_reflections.pop()
+
+    @classmethod
     def reflect_board_across_x(cls, board):
         return (
             board[12],

--- a/envs/nick_2048.py
+++ b/envs/nick_2048.py
@@ -29,6 +29,69 @@ class Nick2048(Base2048):
     def __init__(self, config=None):
         self.reset()
 
+    @classmethod
+    def reflect_board_across_x(cls, board):
+        return (
+            board[12],
+            board[13],
+            board[14],
+            board[15],
+            board[8],
+            board[9],
+            board[10],
+            board[11],
+            board[4],
+            board[5],
+            board[6],
+            board[7],
+            board[0],
+            board[1],
+            board[2],
+            board[3],
+        )
+
+    @classmethod
+    def reflect_board_across_y(cls, board):
+        return (
+            board[3],
+            board[2],
+            board[1],
+            board[0],
+            board[7],
+            board[6],
+            board[5],
+            board[4],
+            board[11],
+            board[10],
+            board[9],
+            board[8],
+            board[15],
+            board[14],
+            board[13],
+            board[12],
+        )
+
+    @classmethod
+    def rotate_board_right(cls, board):
+        return (
+            board[12],
+            board[8],
+            board[4],
+            board[0],
+            board[13],
+            board[9],
+            board[5],
+            board[1],
+            board[14],
+            board[10],
+            board[6],
+            board[2],
+            board[15],
+            board[11],
+            board[7],
+            board[3],
+        )
+
     @property
     def done(self):
         if len(self.empty_indexes) > 0:
@@ -150,45 +213,141 @@ class Nick2048(Base2048):
         return idx
 
     def _do_up(self):
-        sq1, r1 = squash_lookup[(self.board[0], self.board[4], self.board[8], self.board[12])]
-        sq2, r2 = squash_lookup[(self.board[1], self.board[5], self.board[9], self.board[13])]
-        sq3, r3 = squash_lookup[(self.board[2], self.board[6], self.board[10], self.board[14])]
-        sq4, r4 = squash_lookup[(self.board[3], self.board[7], self.board[11], self.board[15])]
-        self.set_board((sq1[0], sq2[0], sq3[0], sq4[0],
-                        sq1[1], sq2[1], sq3[1], sq4[1],
-                        sq1[2], sq2[2], sq3[2], sq4[2],
-                        sq1[3], sq2[3], sq3[3], sq4[3]))
+        sq1, r1 = squash_lookup[
+            (self.board[0], self.board[4], self.board[8], self.board[12])
+        ]
+        sq2, r2 = squash_lookup[
+            (self.board[1], self.board[5], self.board[9], self.board[13])
+        ]
+        sq3, r3 = squash_lookup[
+            (self.board[2], self.board[6], self.board[10], self.board[14])
+        ]
+        sq4, r4 = squash_lookup[
+            (self.board[3], self.board[7], self.board[11], self.board[15])
+        ]
+        self.set_board(
+            (
+                sq1[0],
+                sq2[0],
+                sq3[0],
+                sq4[0],
+                sq1[1],
+                sq2[1],
+                sq3[1],
+                sq4[1],
+                sq1[2],
+                sq2[2],
+                sq3[2],
+                sq4[2],
+                sq1[3],
+                sq2[3],
+                sq3[3],
+                sq4[3],
+            )
+        )
         self.score += r1 + r2 + r3 + r4
 
     def _do_right(self):
-        sq1, r1 = squash_lookup[(self.board[3], self.board[2], self.board[1], self.board[0])]
-        sq2, r2 = squash_lookup[(self.board[7], self.board[6], self.board[5], self.board[4])]
-        sq3, r3 = squash_lookup[(self.board[11], self.board[10], self.board[9], self.board[8])]
-        sq4, r4 = squash_lookup[(self.board[15], self.board[14], self.board[13], self.board[12])]
-        self.set_board((sq1[3], sq1[2], sq1[1], sq1[0],
-                        sq2[3], sq2[2], sq2[1], sq2[0],
-                        sq3[3], sq3[2], sq3[1], sq3[0],
-                        sq4[3], sq4[2], sq4[1], sq4[0]))
+        sq1, r1 = squash_lookup[
+            (self.board[3], self.board[2], self.board[1], self.board[0])
+        ]
+        sq2, r2 = squash_lookup[
+            (self.board[7], self.board[6], self.board[5], self.board[4])
+        ]
+        sq3, r3 = squash_lookup[
+            (self.board[11], self.board[10], self.board[9], self.board[8])
+        ]
+        sq4, r4 = squash_lookup[
+            (self.board[15], self.board[14], self.board[13], self.board[12])
+        ]
+        self.set_board(
+            (
+                sq1[3],
+                sq1[2],
+                sq1[1],
+                sq1[0],
+                sq2[3],
+                sq2[2],
+                sq2[1],
+                sq2[0],
+                sq3[3],
+                sq3[2],
+                sq3[1],
+                sq3[0],
+                sq4[3],
+                sq4[2],
+                sq4[1],
+                sq4[0],
+            )
+        )
         self.score += r1 + r2 + r3 + r4
 
     def _do_down(self):
-        sq1, r1 = squash_lookup[(self.board[12], self.board[8], self.board[4], self.board[0])]
-        sq2, r2 = squash_lookup[(self.board[13], self.board[9], self.board[5], self.board[1])]
-        sq3, r3 = squash_lookup[(self.board[14], self.board[10], self.board[6], self.board[2])]
-        sq4, r4 = squash_lookup[(self.board[15], self.board[11], self.board[7], self.board[3])]
-        self.set_board((sq1[3], sq2[3], sq3[3], sq4[3],
-                        sq1[2], sq2[2], sq3[2], sq4[2],
-                        sq1[1], sq2[1], sq3[1], sq4[1],
-                        sq1[0], sq2[0], sq3[0], sq4[0]))
+        sq1, r1 = squash_lookup[
+            (self.board[12], self.board[8], self.board[4], self.board[0])
+        ]
+        sq2, r2 = squash_lookup[
+            (self.board[13], self.board[9], self.board[5], self.board[1])
+        ]
+        sq3, r3 = squash_lookup[
+            (self.board[14], self.board[10], self.board[6], self.board[2])
+        ]
+        sq4, r4 = squash_lookup[
+            (self.board[15], self.board[11], self.board[7], self.board[3])
+        ]
+        self.set_board(
+            (
+                sq1[3],
+                sq2[3],
+                sq3[3],
+                sq4[3],
+                sq1[2],
+                sq2[2],
+                sq3[2],
+                sq4[2],
+                sq1[1],
+                sq2[1],
+                sq3[1],
+                sq4[1],
+                sq1[0],
+                sq2[0],
+                sq3[0],
+                sq4[0],
+            )
+        )
         self.score += r1 + r2 + r3 + r4
 
     def _do_left(self):
-        sq1, r1 = squash_lookup[(self.board[0], self.board[1], self.board[2], self.board[3])]
-        sq2, r2 = squash_lookup[(self.board[4], self.board[5], self.board[6], self.board[7])]
-        sq3, r3 = squash_lookup[(self.board[8], self.board[9], self.board[10], self.board[11])]
-        sq4, r4 = squash_lookup[(self.board[12], self.board[13], self.board[14], self.board[15])]
-        self.set_board((sq1[0], sq1[1], sq1[2], sq1[3],
-                        sq2[0], sq2[1], sq2[2], sq2[3],
-                        sq3[0], sq3[1], sq3[2], sq3[3],
-                        sq4[0], sq4[1], sq4[2], sq4[3]))
+        sq1, r1 = squash_lookup[
+            (self.board[0], self.board[1], self.board[2], self.board[3])
+        ]
+        sq2, r2 = squash_lookup[
+            (self.board[4], self.board[5], self.board[6], self.board[7])
+        ]
+        sq3, r3 = squash_lookup[
+            (self.board[8], self.board[9], self.board[10], self.board[11])
+        ]
+        sq4, r4 = squash_lookup[
+            (self.board[12], self.board[13], self.board[14], self.board[15])
+        ]
+        self.set_board(
+            (
+                sq1[0],
+                sq1[1],
+                sq1[2],
+                sq1[3],
+                sq2[0],
+                sq2[1],
+                sq2[2],
+                sq2[3],
+                sq3[0],
+                sq3[1],
+                sq3[2],
+                sq3[3],
+                sq4[0],
+                sq4[1],
+                sq4[2],
+                sq4[3],
+            )
+        )
         self.score += r1 + r2 + r3 + r4

--- a/envs/nick_2048.py
+++ b/envs/nick_2048.py
@@ -30,6 +30,19 @@ class Nick2048(Base2048):
         self.reset()
 
     @classmethod
+    def get_afterstate(cls, board, action):
+        game = cls()
+        game.set_board(board)
+        do_action = {
+            cls.UP: game._do_up,
+            cls.RIGHT: game._do_right,
+            cls.DOWN: game._do_down,
+            cls.LEFT: game._do_left,
+        }
+        do_action[action]()
+        return game.board
+
+    @classmethod
     def get_canonical_board(cls, board):
         r0 = board
         r90 = cls.rotate_board_right(board)

--- a/test_nick_2048.py
+++ b/test_nick_2048.py
@@ -1,3 +1,4 @@
+import random
 from envs.nick_2048 import Nick2048
 
 
@@ -219,3 +220,42 @@ def test_reflect_board():
     assert reflected_x_1 == (0, 0, 0, 8, 4, 4, 0, 0, 2, 0, 0, 0, 2, 0, 4, 8)
     reflected_x_2 = Nick2048.reflect_board_across_x(reflected_x_1)
     assert reflected_x_2 == board
+
+
+def _generate_random_board():
+    nums = [0, 0, 0, 0, 0, 2, 2, 2, 2, 4, 4, 4, 8, 8, 16, 32]
+    return tuple([random.choice(nums) for i in range(16)])
+
+
+def test_get_canonical():
+    for i in range(100):
+        board = _generate_random_board()
+        canonical = Nick2048.get_canonical_board(board)
+        r90 = Nick2048.rotate_board_right(board)
+        r180 = Nick2048.rotate_board_right(r90)
+        r270 = Nick2048.rotate_board_right(r180)
+        r360 = Nick2048.rotate_board_right(r270)
+        xr0 = Nick2048.reflect_board_across_x(board)
+        xr90 = Nick2048.rotate_board_right(xr0)
+        xr180 = Nick2048.rotate_board_right(xr90)
+        xr270 = Nick2048.rotate_board_right(xr180)
+        xr360 = Nick2048.rotate_board_right(xr270)
+        yr0 = Nick2048.reflect_board_across_y(board)
+        yr90 = Nick2048.rotate_board_right(yr0)
+        yr180 = Nick2048.rotate_board_right(yr90)
+        yr270 = Nick2048.rotate_board_right(yr180)
+        yr360 = Nick2048.rotate_board_right(yr270)
+        assert canonical == Nick2048.get_canonical_board(r90)
+        assert canonical == Nick2048.get_canonical_board(r180)
+        assert canonical == Nick2048.get_canonical_board(r270)
+        assert canonical == Nick2048.get_canonical_board(r360)
+        assert canonical == Nick2048.get_canonical_board(xr0)
+        assert canonical == Nick2048.get_canonical_board(xr90)
+        assert canonical == Nick2048.get_canonical_board(xr180)
+        assert canonical == Nick2048.get_canonical_board(xr270)
+        assert canonical == Nick2048.get_canonical_board(xr360)
+        assert canonical == Nick2048.get_canonical_board(yr0)
+        assert canonical == Nick2048.get_canonical_board(yr90)
+        assert canonical == Nick2048.get_canonical_board(yr180)
+        assert canonical == Nick2048.get_canonical_board(yr270)
+        assert canonical == Nick2048.get_canonical_board(yr360)

--- a/test_nick_2048.py
+++ b/test_nick_2048.py
@@ -167,3 +167,55 @@ def test_get_valid_actions_by_reward():
     assert action_rewards[3] in up_down
     for (a, r, b) in Nick2048.get_valid_actions_by_reward_from_board(board):
         assert (a, r) in action_rewards
+
+
+def test_rotate_board():
+    # 2 0 4 8
+    # 2 0 0 0
+    # 4 4 0 0
+    # 0 0 0 8
+    board = tuple([2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8])
+    result_90 = Nick2048.rotate_board_right(board)
+    # 0 4 2 2
+    # 0 4 0 0
+    # 0 0 0 4
+    # 8 0 0 8
+    assert result_90 == tuple([0, 4, 2, 2, 0, 4, 0, 0, 0, 0, 0, 4, 8, 0, 0, 8])
+    result_180 = Nick2048.rotate_board_right(result_90)
+    # 8 0 0 0
+    # 0 0 4 4
+    # 0 0 0 2
+    # 8 4 0 2
+    assert result_180 == tuple([8, 0, 0, 0, 0, 0, 4, 4, 0, 0, 0, 2, 8, 4, 0, 2])
+    result_270 = Nick2048.rotate_board_right(result_180)
+    # 8 0 0 8
+    # 4 0 0 0
+    # 0 0 4 0
+    # 2 2 4 0
+    assert result_270 == tuple([8, 0, 0, 8, 4, 0, 0, 0, 0, 0, 4, 0, 2, 2, 4, 0])
+    result_360 = Nick2048.rotate_board_right(result_270)
+    assert result_360 == board
+
+
+def test_reflect_board():
+    # 2 0 4 8
+    # 2 0 0 0
+    # 4 4 0 0
+    # 0 0 0 8
+    board = tuple([2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8])
+    reflected_y_1 = Nick2048.reflect_board_across_y(board)
+    # 8 4 0 2
+    # 0 0 0 2
+    # 0 0 4 4
+    # 8 0 0 0
+    assert reflected_y_1 == tuple([8, 4, 0, 2, 0, 0, 0, 2, 0, 0, 4, 4, 8, 0, 0, 0])
+    reflected_y_2 = Nick2048.reflect_board_across_y(reflected_y_1)
+    assert reflected_y_2 == board
+    reflected_x_1 = Nick2048.reflect_board_across_x(board)
+    # 0 0 0 8
+    # 4 4 0 0
+    # 2 0 0 0
+    # 2 0 4 8
+    assert reflected_x_1 == tuple([0, 0, 0, 8, 4, 4, 0, 0, 2, 0, 0, 0, 2, 0, 4, 8])
+    reflected_x_2 = Nick2048.reflect_board_across_x(reflected_x_1)
+    assert reflected_x_2 == board

--- a/test_nick_2048.py
+++ b/test_nick_2048.py
@@ -174,25 +174,25 @@ def test_rotate_board():
     # 2 0 0 0
     # 4 4 0 0
     # 0 0 0 8
-    board = tuple([2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8])
+    board = (2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8)
     result_90 = Nick2048.rotate_board_right(board)
     # 0 4 2 2
     # 0 4 0 0
     # 0 0 0 4
     # 8 0 0 8
-    assert result_90 == tuple([0, 4, 2, 2, 0, 4, 0, 0, 0, 0, 0, 4, 8, 0, 0, 8])
+    assert result_90 == (0, 4, 2, 2, 0, 4, 0, 0, 0, 0, 0, 4, 8, 0, 0, 8)
     result_180 = Nick2048.rotate_board_right(result_90)
     # 8 0 0 0
     # 0 0 4 4
     # 0 0 0 2
     # 8 4 0 2
-    assert result_180 == tuple([8, 0, 0, 0, 0, 0, 4, 4, 0, 0, 0, 2, 8, 4, 0, 2])
+    assert result_180 == (8, 0, 0, 0, 0, 0, 4, 4, 0, 0, 0, 2, 8, 4, 0, 2)
     result_270 = Nick2048.rotate_board_right(result_180)
     # 8 0 0 8
     # 4 0 0 0
     # 0 0 4 0
     # 2 2 4 0
-    assert result_270 == tuple([8, 0, 0, 8, 4, 0, 0, 0, 0, 0, 4, 0, 2, 2, 4, 0])
+    assert result_270 == (8, 0, 0, 8, 4, 0, 0, 0, 0, 0, 4, 0, 2, 2, 4, 0)
     result_360 = Nick2048.rotate_board_right(result_270)
     assert result_360 == board
 
@@ -202,13 +202,13 @@ def test_reflect_board():
     # 2 0 0 0
     # 4 4 0 0
     # 0 0 0 8
-    board = tuple([2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8])
+    board = (2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8)
     reflected_y_1 = Nick2048.reflect_board_across_y(board)
     # 8 4 0 2
     # 0 0 0 2
     # 0 0 4 4
     # 8 0 0 0
-    assert reflected_y_1 == tuple([8, 4, 0, 2, 0, 0, 0, 2, 0, 0, 4, 4, 8, 0, 0, 0])
+    assert reflected_y_1 == (8, 4, 0, 2, 0, 0, 0, 2, 0, 0, 4, 4, 8, 0, 0, 0)
     reflected_y_2 = Nick2048.reflect_board_across_y(reflected_y_1)
     assert reflected_y_2 == board
     reflected_x_1 = Nick2048.reflect_board_across_x(board)
@@ -216,6 +216,6 @@ def test_reflect_board():
     # 4 4 0 0
     # 2 0 0 0
     # 2 0 4 8
-    assert reflected_x_1 == tuple([0, 0, 0, 8, 4, 4, 0, 0, 2, 0, 0, 0, 2, 0, 4, 8])
+    assert reflected_x_1 == (0, 0, 0, 8, 4, 4, 0, 0, 2, 0, 0, 0, 2, 0, 4, 8)
     reflected_x_2 = Nick2048.reflect_board_across_x(reflected_x_1)
     assert reflected_x_2 == board

--- a/test_nick_2048.py
+++ b/test_nick_2048.py
@@ -259,3 +259,19 @@ def test_get_canonical():
         assert canonical == Nick2048.get_canonical_board(yr180)
         assert canonical == Nick2048.get_canonical_board(yr270)
         assert canonical == Nick2048.get_canonical_board(yr360)
+
+
+def test_get_afterstate():
+    # 2 0 4 8
+    # 2 0 0 0
+    # 4 4 0 0
+    # 0 0 0 8
+    board = (2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8)
+    after_up = Nick2048.get_afterstate(board, Nick2048.UP)
+    assert after_up == (4, 4, 4, 16, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    after_down = Nick2048.get_afterstate(board, Nick2048.DOWN)
+    assert after_down == (0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 4, 4, 16)
+    after_left = Nick2048.get_afterstate(board, Nick2048.LEFT)
+    assert after_left == (2, 4, 8, 0, 2, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0)
+    after_right = Nick2048.get_afterstate(board, Nick2048.RIGHT)
+    assert after_right == (0, 2, 4, 8, 0, 0, 0, 2, 0, 0, 0, 8, 0, 0, 0, 8)


### PR DESCRIPTION
FYI @andyk.  Let me know if the board canonicalization method strikes you as legit.

This lays some groundwork for my implementation of TD learning.  Implements five new class methods in `Nick2048`.

* `get_afterstate(board, action)`- returns the result of taking `action` on `board` *without* placing a new random 2 or 4.

* `get_canonical_board(board)` - returns the canonical board for the given `board`.  It does this by first enumerating all rotations of `board`, all rotations of `board` when reflected across the vertical plane, and all rotations of `board` when reflected across the horizontal plane (12 in total).  It then dedups these rotations using a `set`.  It finally returns the board with the max in index 0 (using index 1 as a tiebreak, then index 2 as a tiebreak *for that*, etc).  I think you basically pitched me this algorithm on our call last night--let me know if it stills seems right to you (the test suggests it's working).

* ` reflect_board_across_x(board)` - returns board reflected across the horizontal axis.

* ` reflect_board_across_y(board)` - returns board reflected across the vertical axis.

* `rotate_board_right(board)` - returns board rotated 90 degrees to the right.

