### PR TITLE
Q-learning (off-policy TD control) for cartpole and 2048

### DIFF
--- a/contrib/sarsa.py
+++ b/contrib/sarsa.py
@@ -66,7 +66,7 @@ class Sarsa(Trainable):
                         logging.debug(f"state:\n{np.asarray(state).reshape([4,4])}")
                         candidate_actions = list(range(b.action_space.n))
                         canonical_afterstates = [
-                            b.get_canonical_board(b.get_afterstate(state, a))
+                            b.get_canonical_board(b.get_afterstate(state, a)[0])
                             for a in candidate_actions
                         ]
                         q_vals = [
@@ -114,7 +114,7 @@ class Sarsa(Trainable):
                         # update q_model via TD learning using q(s,a) (which we computed last loop iter) and q(s',a')
                         next_candidate_actions = list(range(b.action_space.n))
                         next_canonical_afterstates = [
-                            b.get_canonical_board(b.get_afterstate(next_state, action))
+                            b.get_canonical_board(b.get_afterstate(next_state, action)[0])
                             for action in next_candidate_actions
                         ]
                         next_q_vals = [

--- a/do_stats.py
+++ b/do_stats.py
@@ -80,6 +80,7 @@ STRATEGIES = {
     "mcts_dynamic": try_mcts_dynamic,
     "lookahead_with_rollout": try_lookahead_with_rollout,
     "nick_q_learning": None,  # only import if used for perf
+    "nick_q_learning_cartpole": None,  # only import if used for perf
 }
 
 
@@ -134,6 +135,11 @@ if __name__ == "__main__":
         from strategies.nick_q_learning import try_nick_q_learning
 
         STRATEGIES["nick_q_learning"] = try_nick_q_learning
+
+    if strat_name == "nick_q_learning_cartpole":
+        from strategies.nick_q_learning import try_nick_q_learning_cartpole
+
+        STRATEGIES["nick_q_learning_cartpole"] = try_nick_q_learning_cartpole
 
     implementation = IMPLEMENTATIONS[impl_name]
     strategy = STRATEGIES[strat_name]

--- a/envs/base_2048.py
+++ b/envs/base_2048.py
@@ -3,6 +3,7 @@ import random
 
 
 class Base2048(gym.Env):
+    STATE_LEN = 16
     @classmethod
     def get_valid_actions_from_board(cls, board):
         test_game = cls()

--- a/envs/nick_2048.py
+++ b/envs/nick_2048.py
@@ -31,6 +31,11 @@ class Nick2048(Base2048):
         self.reset()
 
     @classmethod
+    def get_canonical_afterstate(cls, board, action):
+        afterstate, reward = cls.get_afterstate(board, action)
+        return cls.get_canonical_board(afterstate)
+
+    @classmethod
     def get_afterstate(cls, board, action):
         game = cls()
         game.set_board(board)
@@ -41,7 +46,7 @@ class Nick2048(Base2048):
             cls.LEFT: game._do_left,
         }
         do_action[action]()
-        return game.board
+        return game.board, game.score
 
     @classmethod
     def get_canonical_board(cls, board):

--- a/envs/nick_cartpole_adapter.py
+++ b/envs/nick_cartpole_adapter.py
@@ -1,0 +1,56 @@
+# This is a somewhat hacky adapter that allows drop-in replacement of the
+# 2048 environment with a cartpole environment to test the implementation
+# of Q-learning (off-policy TD control) in strategies/nick_q_learning.py
+from decimal import Decimal
+import gym
+
+
+class NickCartpoleAdapter:
+    STATE_LEN = 4
+    action_space = (0, 1)
+
+    def __init__(self):
+        self.env = gym.make("CartPole-v0")
+        self.max_steps = 200
+        self.reset()
+
+    def reset(self):
+        self.state = tuple(self.env.reset())
+        self.step_count = 0
+        self.total_reward = 0
+        self.env_is_done = False
+
+    def step(self, action):
+        assert action in self.action_space
+        next_state, reward, done, _ = self.env.step(action)
+        self.state = tuple(next_state)
+        self.total_reward += int(reward)
+        self.env_is_done = bool(done)
+        self.step_count += 1
+        return self.state, int(reward), self.done, None
+
+    def set_board(self, state):
+        # TODO - make this actual set env state?
+        pass
+
+    def get_valid_actions(self):
+        return ((0, None, None), (1, None, None))
+
+    def get_state(self):
+        return self.state, self.score, self.done
+
+    @classmethod
+    def get_canonical_afterstate(cls, state, action):
+        return tuple([round(Decimal(el), 1) for el in state])
+
+    @property
+    def score(self):
+        return self.total_reward
+
+    @property
+    def board(self):
+        return self.state
+
+    @property
+    def done(self):
+        return self.step_count > self.max_steps or self.env_is_done

--- a/strategies/nick_q_learning.py
+++ b/strategies/nick_q_learning.py
@@ -1,4 +1,5 @@
-# Q learning as presented on Sutton and Barto p131 (p153 in trimmed pdf)
+# Q-learning (off-policy TD control) as presented in
+# Sutton and Barto p131 (p153 in trimmed pdf)
 # Run on 2048:
 #   python do_stats.py nick 100 nick_q_learning
 # Run on cartpole:

--- a/strategies/nick_q_learning.py
+++ b/strategies/nick_q_learning.py
@@ -1,10 +1,16 @@
 # Q learning as presented on Sutton and Barto p131 (p153 in trimmed pdf)
+# Run on 2048:
+#   python do_stats.py nick 100 nick_q_learning
+# Run on cartpole:
+#   python do_stats.py nick 100 nick_q_learning_cartpole
 from collections import defaultdict
 import random
 import time
 import sys
 
-from envs.nick_2048 import Nick2048
+import mlflow
+
+from envs.nick_cartpole_adapter import NickCartpoleAdapter
 from strategies.utility import do_trials
 
 ALPHA = 0.1
@@ -13,11 +19,27 @@ DISCOUNT = 0.95
 
 
 class QTable:
-    def __init__(self):
+    def __init__(self, test_cls):
+        self.test_cls = test_cls
         self.q_table = defaultdict(int)
         self.reset_counters()
 
+    def get_max_action(self, board):
+        test_game = self.test_cls()
+        test_game.set_board(board)
+        actions = [a for a, _, _ in test_game.get_valid_actions()]
+        if not actions:
+            return None
+        action_values = []
+        for action in actions:
+            canonical = self.test_cls.get_canonical_afterstate(board, action)
+            val = self.get(canonical, action)
+            action_values.append((val, action))
+        return max(action_values)[1]
+
     def get(self, state, action):
+        assert len(state) == self.test_cls.STATE_LEN
+        assert action in self.test_cls.action_space
         self.lookups += 1
         if (state, action) in self.q_table:
             self.hits += 1
@@ -27,18 +49,22 @@ class QTable:
         return val
 
     def set(self, state, action, val):
+        assert len(state) == self.test_cls.STATE_LEN
+        assert action in self.test_cls.action_space
         self.q_table[(state, action)] = val
 
     def learn(self, curr_state, action, reward, next_state):
-        curr_q = self.get(curr_state, action)
-        action_tuples = Nick2048.get_valid_actions_from_board(next_state)
-        actions = [a for a, _, _ in action_tuples]
-        if not actions:  # game is over
+        curr_canonical = self.test_cls.get_canonical_afterstate(curr_state, action)
+        curr_q = self.get(curr_canonical, action)
+        max_next_action = self.get_max_action(next_state)
+        if max_next_action is None:  # game is done
             return
-        next_action_values = [(self.get(next_state, a), a) for a in actions]
-        max_next_q, _ = max(next_action_values)
-        q_update = ALPHA * (reward + DISCOUNT * max_next_q - curr_q)
-        self.set(curr_state, action, curr_q + q_update)
+        next_canonical = self.test_cls.get_canonical_afterstate(
+            next_state, max_next_action
+        )
+        max_next_q = self.get(next_canonical, max_next_action)
+        q_update = ALPHA * (reward + (DISCOUNT * max_next_q) - curr_q)
+        self.set(curr_canonical, action, curr_q + q_update)
 
     def reset_counters(self):
         self.lookups = 0
@@ -87,73 +113,106 @@ def run_episode(game, q_table):
 
 def choose_action_epsilon_greedily(game, q_table):
     random.seed(time.time())
-    actions = [a for a, _, _ in game.get_valid_actions()]
     if random.random() < EPSILON:
+        actions = [a for a, _, _ in game.get_valid_actions()]
         return random.choice(actions)
     else:
-        action_values = [
-            (q_table.get(game.board, action), action) for action in actions
-        ]
-        return max(action_values)[1]
+        return q_table.get_max_action(game.board)
 
 
-def try_nick_q_learning(cls, trial_count):
+def _try_nick_q_learning(cls, trial_count):
     start = time.time()
     i = 0
-    total_score = 0
     last_scores_to_store = 10
-    last_x_scores = []
-    game = Nick2048()
-    q_table = QTable()
+    all_scores = []
+    game = cls()
+    q_table = QTable(cls)
     while True:
         run_episode(game, q_table)
-        total_score += game.score
-        last_x_scores.append(game.score)
-        while len(last_x_scores) > last_scores_to_store:
-            last_x_scores.pop(0)
+        all_scores.append(game.score)
         i += 1
         if i % 100 == 0:
             total_sec = round(time.time() - start, 2)
             sec_per_iter = round(total_sec / i, 2)
-            avg_game_score = round(total_score / i, 0)
+            max_game_score = round(max(all_scores), 0)
+            mean_game_score = round(sum(all_scores) / len(all_scores), 0)
+            last_score_idx = -1 * last_scores_to_store
+            last_x_scores = all_scores[last_score_idx:]
             avg_last_x = round(sum(last_x_scores) / len(last_x_scores), 2)
             print(
                 f"Training iteration {i} "
                 f"({total_sec} sec total, {sec_per_iter} sec per iter)"
                 f"\n\tLast {last_scores_to_store}: {last_x_scores} "
                 f"(avg: {avg_last_x})"
-                f"\n\tMean game score: {avg_game_score}"
+                f"\n\tMax game score: {max_game_score}"
+                f"\n\tMean game score: {mean_game_score}"
                 f"\n\tSize of state value table: "
                 f"{round(q_table.size_in_mb, 2)}MB"
-                f"\n\tState value hit rate: "
+                f"\n\tQ table hit rate: "
                 f"{round(q_table.hit_rate, 2)}% "
                 f"({q_table.lookup_hits} out of "
                 f"{q_table.lookup_count})"
-                f"\n\tState value non-zero hit rate: "
+                f"\n\tQ table non-zero hit rate: "
                 f"{round(q_table.nonzero_hit_rate, 2)}% "
                 f"({q_table.lookup_nonzero_hits} out of "
                 f"{q_table.lookup_count})\n"
             )
+            all_scores = []
             q_table.reset_counters()
         if i % 1000 == 0:
             q_table.reset_counters()
 
             def q_learning_benchmark_fn(board):
-                action_tuples = Nick2048.get_valid_actions_from_board(board)
-                actions = [a for a, _, _ in action_tuples]
-                action_values = [(q_table.get(board, a), a) for a in actions]
-                return max(action_values)[1]
+                return q_table.get_max_action(board)
 
             q_learning_benchmark_fn.info = f"Q-learning iteration {i}"
-            do_trials(cls, trial_count, q_learning_benchmark_fn)
+            results = do_trials(cls, trial_count, q_learning_benchmark_fn)
+            mlflow.log_metric("max tile", results["Max Tile"], step=i)
+            mlflow.log_metric("max score", results["Max Score"], step=i)
+            mlflow.log_metric("mean score", results["Mean Score"], step=i)
+            mlflow.log_metric("median score", results["Median Score"], step=i)
+            mlflow.log_metric("stdev", results["Standard Dev"], step=i)
+            mlflow.log_metric("min score", results["Min Score"], step=i)
+            mlflow.log_metric("q hit rate", q_table.hit_rate, step=i)
+            mlflow.log_metric("q nonzero hit rate", q_table.nonzero_hit_rate, step=i)
+            mlflow.log_metric("q size", q_table.size_in_mb, step=1)
+
             print(
-                f"State value hit rate: "
+                f"Q table hit rate: "
                 f"{round(q_table.hit_rate, 2)}% "
                 f"({q_table.lookup_hits} out of "
                 f"{q_table.lookup_count})\n"
-                f"State value non-zero hit rate: "
+                f"Q table non-zero hit rate: "
                 f"{round(q_table.nonzero_hit_rate, 2)}% "
                 f"({q_table.lookup_nonzero_hits} out of "
-                f"{q_table.lookup_count})\n\n"
+                f"{q_table.lookup_count})\n"
+                f"Size of state value table: "
+                f"{round(q_table.size_in_mb, 2)}MB\n\n"
                 f"=================\n\n"
             )
+
+
+def try_nick_q_learning(cls, trial_count):
+    with mlflow.start_run():
+        mlflow.log_params(
+            {
+                "alpha": ALPHA,
+                "epsilon": EPSILON,
+                "discount rate": DISCOUNT,
+                "desc": "q learning on 2048 w/ canonical afterstates",
+            }
+        )
+        return _try_nick_q_learning(cls, trial_count)
+
+
+def try_nick_q_learning_cartpole(cls, trial_count):
+    with mlflow.start_run():
+        mlflow.log_params(
+            {
+                "alpha": ALPHA,
+                "epsilon": EPSILON,
+                "discount rate": DISCOUNT,
+                "desc": "q learning on CARTPOLE w/ canonical afterstates",
+            }
+        )
+        return _try_nick_q_learning(NickCartpoleAdapter, trial_count)

--- a/tests/test_nick_2048.py
+++ b/tests/test_nick_2048.py
@@ -268,14 +268,18 @@ def test_get_afterstate():
     # 4 4 0 0
     # 0 0 0 8
     board = (2, 0, 4, 8, 2, 0, 0, 0, 4, 4, 0, 0, 0, 0, 0, 8)
-    after_up = Nick2048.get_afterstate(board, Nick2048.UP)
+    after_up, up_reward = Nick2048.get_afterstate(board, Nick2048.UP)
     assert after_up == (4, 4, 4, 16, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    after_down = Nick2048.get_afterstate(board, Nick2048.DOWN)
+    assert up_reward == 20
+    after_down, down_reward = Nick2048.get_afterstate(board, Nick2048.DOWN)
     assert after_down == (0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 4, 4, 4, 16)
-    after_left = Nick2048.get_afterstate(board, Nick2048.LEFT)
+    assert down_reward == 20
+    after_left, left_reward = Nick2048.get_afterstate(board, Nick2048.LEFT)
     assert after_left == (2, 4, 8, 0, 2, 0, 0, 0, 8, 0, 0, 0, 8, 0, 0, 0)
-    after_right = Nick2048.get_afterstate(board, Nick2048.RIGHT)
+    assert left_reward == 8
+    after_right, right_reward = Nick2048.get_afterstate(board, Nick2048.RIGHT)
     assert after_right == (0, 2, 4, 8, 0, 0, 0, 2, 0, 0, 0, 8, 0, 0, 0, 8)
+    assert right_reward == 8
 
 
 def _run_game(game):


### PR DESCRIPTION
This implements Q-learning using a table lookup for 2048 (with after states and canonicalization).  Pseudocode from Sutton and Barto:

![Screen Shot 2020-02-07 at 1 11 39 PM](https://user-images.githubusercontent.com/25208102/74105634-8bd7ab00-4b2d-11ea-804b-a97a4609c7c3.png)


To try it out, run:

```
python do_stats.py nick 100 nick_q_learning
``` 

Results are not particularly impressive (random-ish scores with maybe 20% non-zero hit rate after a few hours of training).

I also wrote [a kludgy adapter](https://github.com/nickjalbert/improved-funicular/compare/nj_q_learn_2_pr?expand=1#diff-9be3cd82c948709b2374e9f1087147b9R8) that allows drop-in replacement of cartpole for 2048 in the Q-learning implementation as a sanity check.  The results here were much better although it learns *very* slowly (to be fair, though, I did no hyperparameter tuning):

![Screen Shot 2020-02-09 at 11 02 11 AM](https://user-images.githubusercontent.com/25208102/74105435-b294e200-4b2b-11ea-943d-b345d4f09bc8.png)

Each point on the graph is the {median, mean} reward of 100 runs of purely on-policy control (i.e. epsilon == 0).

You can try this out by running:

```
python do_stats.py nick 100 nick_q_learning_cartpole
```

Some more detailed results from the cartpole learning run (272k training plays, ~36hr training time):

```
Final Results
Q-learning iteration 272000 (100 trials, 32.14 sec total, 0.3214 sec per trial):

	Mean steps per game: 191.8
	Mean time per step: 0.00168

	Max Tiles:
		<...snip...>

	Max Score: 200
	Mean Score: 191.82
	Median Score: 198.0
	Standard Dev: 11.280070921762858
	Min Score: 152

Q table hit rate: 100.0% (38364 out of 38364)
Q table non-zero hit rate: 99.96% (38349 out of 38364)
Size of state value table: 2.5MB
```